### PR TITLE
fix parsing of multiple directories in psr-4

### DIFF
--- a/src/Suin/Sniffs/Classes/PSR4/AutoloadabilityInspectorsFactory.php
+++ b/src/Suin/Sniffs/Classes/PSR4/AutoloadabilityInspectorsFactory.php
@@ -40,20 +40,30 @@ final class AutoloadabilityInspectorsFactory
         $psr4Directories = [];
 
         if (isset($data['autoload']['psr-4'])) {
-            foreach ($data['autoload']['psr-4'] as $namespace => $dir) {
-                $psr4Directories[] = new AutoloadabilityInspector(
-                    \dirname($filename) . '/' . $dir,
-                    $namespace
-                );
+            foreach ($data['autoload']['psr-4'] as $namespace => $dirs) {
+                if (!is_array($dirs)) {
+                    $dirs = [$dirs];
+                }
+                foreach ($dirs as $dir) {
+                    $psr4Directories[] = new AutoloadabilityInspector(
+                        \dirname($filename) . '/' . $dir,
+                        $namespace
+                    );
+                }
             }
         }
 
         if (isset($data['autoload-dev']['psr-4'])) {
-            foreach ($data['autoload-dev']['psr-4'] as $namespace => $dir) {
-                $psr4Directories[] = new AutoloadabilityInspector(
-                    \dirname($filename) . '/' . $dir,
-                    $namespace
-                );
+            foreach ($data['autoload-dev']['psr-4'] as $namespace => $dirs) {
+                if (!is_array($dirs)) {
+                    $dirs = [$dirs];
+                }
+                foreach ($dirs as $dir) {
+                    $psr4Directories[] = new AutoloadabilityInspector(
+                        \dirname($filename) . '/' . $dir,
+                        $namespace
+                    );
+                }
             }
         }
         return new AutoloadabilityInspectors(...$psr4Directories);


### PR DESCRIPTION
Fix issue with parsing such block in composer.json
```
    "autoload": {
        "psr-4": {
            "Application\\": [
                "src/application",
                "src/applicationLegacy"
            ]
        }
    },
```