### PR TITLE
Use {$var} instead of ${var}

### DIFF
--- a/src/Suin/Sniffs/Classes/PSR4/AutoloadabilityInspectorsFactory.php
+++ b/src/Suin/Sniffs/Classes/PSR4/AutoloadabilityInspectorsFactory.php
@@ -82,7 +82,7 @@ final class AutoloadabilityInspectorsFactory
     {
         if (!\is_file($filename)) {
             throw new InvalidArgumentException(
-                "composer.json file not found: ${filename}"
+                "composer.json file not found: {$filename}"
             );
         }
     }
@@ -91,7 +91,7 @@ final class AutoloadabilityInspectorsFactory
     {
         if (!\is_readable($filename)) {
             throw new InvalidArgumentException(
-                "composer.json file is not readable: ${filename}"
+                "composer.json file is not readable: {$filename}"
             );
         }
     }


### PR DESCRIPTION
# 背景
[php8.2](https://www.php.net/releases/8.2/ja.php)で`${var}`による文字列への埋め込みが非推奨になった

php8.2環境で、phpcs-psr4-sniffをインストールしphpcsを実行した結果
```sh
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 1 | ERROR | An error occurred during processing; checking has been
   |       | aborted. The error message was: Using ${var} in strings
   |       | is deprecated, use {$var} instead in
   |       | /deploy/vendor/suin/phpcs-psr4-sniff/src/Suin/Sniffs/Classes/PSR4/AutoloadabilityInspectorsFactory.php
   |       | on line 85 (Internal.Exception)
----------------------------------------------------------------------

Time: 3.27 secs; Memory: 26MB

Script ./vendor/bin/phpcs handling the phpcs event returned with error code 1

```